### PR TITLE
Implement a return proxy to avoid needing to block the frontend

### DIFF
--- a/adaptivefiltering/filter.py
+++ b/adaptivefiltering/filter.py
@@ -288,8 +288,6 @@ def serialize_filter(filter_):
     This relies on :func:`~adaptivefilter.filter.Filter._serialize` to do the
     object serialization, but adds information about the correct filter type.
     """
-    assert isinstance(filter_, Filter)
-
     data = filter_._serialize()
     data["_backend"] = filter_._identifier
     return data

--- a/doc/environment-rtd.yml
+++ b/doc/environment-rtd.yml
@@ -18,7 +18,6 @@ dependencies:
     - Click
     - geodaisy
     - geojson
-    - ipython_blocking
     - jsonmerge
     - jsonschema
     - m2r2

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,6 @@ dependencies:
     - Click
     - geodaisy
     - geojson
-    - ipython_blocking
     - jsonmerge
     - jsonschema
     - matplotlib

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
         "geodaisy",
         "geojson",
         "ipympl",
-        "ipython_blocking",
         "IPython==7.21.0",
         "ipyvolume",
         "ipywidgets<8",

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -1,0 +1,27 @@
+from adaptivefiltering.apps import *
+
+import dataclasses
+import ipywidgets
+
+
+@dataclasses.dataclass
+class Obj:
+    data: str
+
+
+def test_return_proxy():
+    # Create a proxy for a widget state
+    w = ipywidgets.Text()
+    proxy = InteractiveWidgetOutputProxy(lambda: Obj(w.value))
+    assert proxy.data == ""
+
+    # Update the widget and observe changes of the proxy
+    w.value = "Foo"
+    assert proxy.data == "Foo"
+
+    # Finalize the proxy
+    proxy._finalize()
+
+    # Ensure that changes to the widgets do not change the proxy anymore
+    w.value = "Bar"
+    assert proxy.data == "Foo"


### PR DESCRIPTION
@GwydionJon You might be interested in this.

This is a major new tool for designing frontend widgets. Instead of needing to block the frontend with the hacky, unstable `ipython_blocking`, frontend widgets can now immediately return a proxy object of type `InteractiveWidgetOutputProxy`. The object can be used instead of the actual object (duck typing!), recreating it from the widget on the fly. Once it has been finalized, no further updating happens (this can e.g. be attached to a Finalize-Button in the UI).