### PR TITLE
Make RichDEM a conda dependency

### DIFF
--- a/doc/environment-rtd.yml
+++ b/doc/environment-rtd.yml
@@ -14,6 +14,7 @@ dependencies:
   - python-pdal=2.4.0
   - gdal=3.3.0
   - pip=21.1.3
+  - richdem=0.3.4
   - pip:
     - Click
     - geodaisy
@@ -28,4 +29,3 @@ dependencies:
     - xdg
     - ipyleaflet
     - xmltodict
-    - richdem

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - pdal=2.3.0
   - python-pdal=2.4.2
   - pip
+  - richdem
   - pip:
     - Click
     - geodaisy
@@ -23,4 +24,3 @@ dependencies:
     - pyrsistent
     - xdg
     - xmltodict
-    - richdem


### PR DESCRIPTION
Correctly tracks the C++ dependencies of the library