### PR TITLE
Add tooltips from the PDAL documentation

### DIFF
--- a/adaptivefiltering/schema/pdal.json
+++ b/adaptivefiltering/schema/pdal.json
@@ -13,12 +13,14 @@
         },
         "class": {
           "default": 7,
-          "title": "Classification value to apply to noise points",
+          "description": "Classification value to apply to noise points",
+          "title": "Class value",
           "type": "integer"
         },
         "threshold": {
           "default": 1.0,
-          "title": "Threshold value to identify low noise points",
+          "description": "Threshold value to identify low noise points",
+          "title": "Threshold",
           "type": "number"
         },
         "type": {
@@ -40,7 +42,8 @@
         },
         "class": {
           "default": 7,
-          "title": "The classification value to apply to outliers",
+          "description": "The classification value to apply to outliers",
+          "title": "Class value",
           "type": "integer"
         },
         "mean_k": {
@@ -76,7 +79,8 @@
         },
         "class": {
           "default": 7,
-          "title": "The classification value to apply to outliers",
+          "description": "The classification value to apply to outliers",
+          "title": "Class value",
           "type": "integer"
         },
         "method": {
@@ -134,7 +138,8 @@
         },
         "exponential": {
           "default": true,
-          "title": "Use exponential growth for window sizes?",
+          "description": "Use exponential growth for window sizes?",
+          "title": "Exponential",
           "type": "boolean"
         },
         "initial_distance": {
@@ -154,7 +159,8 @@
         },
         "returns": {
           "default": "last,only",
-          "title": "Retrun types to include in output",
+          "description": "Comma-separated list of return types into which data should be segmented. Valid groups are \u201clast\u201d, \u201cfirst\u201d, \u201cintermediate\u201d and \u201conly\u201d.",
+          "title": "Return types",
           "type": "string"
         },
         "slope": {
@@ -186,12 +192,14 @@
         },
         "cut": {
           "default": 0.0,
+          "description": "Cut net size (cut=0 skips the net cutting step).",
           "title": "Cut net size",
           "type": "number"
         },
         "returns": {
           "default": "last,only",
-          "title": "Return types to include in output",
+          "description": "Return types to include in output. Valid values are \u201cfirst\u201d, \u201clast\u201d, \u201cintermediate\u201d and \u201conly\u201d.",
+          "title": "Return types",
           "type": "string"
         },
         "scalar": {
@@ -201,7 +209,8 @@
         },
         "slope": {
           "default": 0.15,
-          "title": "Slope (rise over run)",
+          "description": "Slope (rise over run)",
+          "title": "Slope",
           "type": "number"
         },
         "threshold": {
@@ -233,7 +242,8 @@
         },
         "iterations": {
           "default": 500,
-          "title": "Maximum number of iterations",
+          "description": "Maximum number of iterations",
+          "title": "Iterations",
           "type": "integer"
         },
         "resolution": {
@@ -243,7 +253,8 @@
         },
         "returns": {
           "default": "last,only",
-          "title": "Return types to include in output",
+          "description": "Return types to include in output. Valid values are \u201cfirst\u201d, \u201clast\u201d, \u201cintermediate\u201d and \u201conly\u201d.",
+          "title": "Return types",
           "type": "string"
         },
         "rigidness": {
@@ -253,7 +264,8 @@
         },
         "smooth": {
           "default": true,
-          "title": "Perform slope post-processing?",
+          "description": "Perform slope post-processing?",
+          "title": "Smoothness",
           "type": "boolean"
         },
         "step": {

--- a/adaptivefiltering/schema/pipeline.json
+++ b/adaptivefiltering/schema/pipeline.json
@@ -7,12 +7,18 @@
     "metadata": {
       "properties": {
         "author": {
+          "description": "The author of this filter pipeline, used as a filtering criterion in pipeline browsing",
+          "title": "Author",
           "type": "string"
         },
         "description": {
+          "description": "A description of the filtering pipeline: What terrain is it suited best for?",
+          "title": "Description",
           "type": "string"
         },
         "example_data_url": {
+          "description": "An optional URL to a public data set that illustrates the qualities of this pipeline",
+          "title": "Example data set URL",
           "type": "string"
         },
         "keywords": {
@@ -25,6 +31,8 @@
           "type": "array"
         },
         "title": {
+          "description": "A good descriptive name for the filter pipeline",
+          "title": "Filter pipeline name:",
           "type": "string"
         }
       },

--- a/adaptivefiltering/schema/visualization.json
+++ b/adaptivefiltering/schema/visualization.json
@@ -5,6 +5,7 @@
       "properties": {
         "alg": {
           "default": "Horn",
+          "description": "The literature suggests Zevenbergen & Thorne to be more suited to smooth landscapes, whereas Horn\u2019s formula to perform better on rougher terrain.",
           "enum": [
             "Horn",
             "ZevenbergenThorne"
@@ -14,6 +15,7 @@
         },
         "altitude": {
           "default": 30,
+          "description": "Altitude of the light, in degrees. 90 if the light comes from above the DEM, 0 if it is raking light.",
           "maximum": 90,
           "minimum": 0,
           "title": "Angle Altitude (0 to 90 degrees)",
@@ -21,6 +23,7 @@
         },
         "azimuth": {
           "default": 315,
+          "description": "Azimuth of the light, in degrees. 0 if it comes from the top of the raster, 90 from the east, \u2026 The default value, 315, should rarely be changed as it is the value generally used to generate shaded maps.",
           "maximum": 360,
           "minimum": 0,
           "title": "Azimuth angle (0 to 360 degrees)",
@@ -32,8 +35,9 @@
         },
         "zFactor": {
           "default": 1.0,
+          "description": "Vertical exaggeration used to pre-multiply the elevations",
           "minimum": 0.0,
-          "title": "Vertical exaggeration factor",
+          "title": "Vertical exaggeration:",
           "type": "number"
         }
       },


### PR DESCRIPTION
This adds the necessary information to the schema. Implementation of #102 is still not working because ipywidgets only shows the tooltips for string, selection and boolean inputs, but no numbers.