### PR TITLE
Disambiguate OPALS and lastools filter schemas

### DIFF
--- a/adaptivefiltering/lastools.py
+++ b/adaptivefiltering/lastools.py
@@ -72,6 +72,12 @@ class LASToolsFilter(Filter, identifier="lastools", backend=True):
         # Build the argument list
         args = []
         for k, v in config.items():
+            # The type key is just there to disambiguate filter schemas,
+            # it is not actually part of the backend but could be used in
+            # the future to also expose lasground.exe
+            if k == "type":
+                continue
+
             strv = stringify_value(v)
             if strv != "":
                 args.append(f"-{k}")

--- a/adaptivefiltering/schema/lastools.json
+++ b/adaptivefiltering/schema/lastools.json
@@ -18,8 +18,15 @@
         "step": {
           "default": 1.0,
           "type": "number"
+        },
+        "type": {
+          "const": "lasground_new",
+          "type": "string"
         }
       },
+      "required": [
+        "type"
+      ],
       "title": "lasground_new (LASTools)",
       "type": "object"
     }


### PR DESCRIPTION
Fixes a bug reported by Michael where adaptivefiltering could not distinguish filter configurations from config introspection solely.