### PR TITLE
removed Segment class

### DIFF
--- a/adaptivefiltering/dataset.py
+++ b/adaptivefiltering/dataset.py
@@ -180,11 +180,7 @@ class DataSet:
         :type: adaptivefiltering.segmentation.Segmentation
         """
 
-        from adaptivefiltering.segmentation import Segment, Segmentation
         from adaptivefiltering.apps import apply_restriction
-
-        if isinstance(segmentation, Segment):
-            segmentation = Segmentation([segmentation.__geo_interface__])
 
         return apply_restriction(self, segmentation)
 

--- a/adaptivefiltering/pdal.py
+++ b/adaptivefiltering/pdal.py
@@ -2,7 +2,6 @@ from adaptivefiltering.asprs import asprs
 from adaptivefiltering.dataset import DataSet
 from adaptivefiltering.filter import Filter, PipelineMixin
 from adaptivefiltering.paths import get_temporary_filename, load_schema, locate_file
-from adaptivefiltering.segmentation import Segment, Segmentation, swap_coordinates
 from adaptivefiltering.utils import (
     AdaptiveFilteringError,
     check_spatial_reference,

--- a/adaptivefiltering/segmentation.py
+++ b/adaptivefiltering/segmentation.py
@@ -19,31 +19,6 @@ import collections
 import copy
 
 
-class Segment:
-    def __init__(self, polygon, metadata={}):
-        self.polygon = geojson.Polygon(polygon)
-        self.metadata = metadata
-
-    @property
-    def metadata(self):
-        return self._metadata
-
-    @metadata.setter
-    def metadata(self, _metadata):
-        # Validate against our segment metadata schema
-        schema = load_schema("segment_metadata.json")
-        jsonschema.validate(instance=_metadata, schema=schema)
-        self._metadata = _metadata
-
-    @property
-    def __geo_interface__(self):
-        return {
-            "type": "Feature",
-            "geometry": self.polygon,
-            "properties": self.metadata,
-        }
-
-
 class Segmentation(geojson.FeatureCollection):
     @classmethod
     def load(cls, filename=None):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,6 +1,6 @@
 from adaptivefiltering.dataset import *
 from adaptivefiltering.paths import get_temporary_filename
-from adaptivefiltering.segmentation import Segment, Segmentation
+from adaptivefiltering.segmentation import Segmentation
 from adaptivefiltering.asprs import asprs
 from adaptivefiltering.pdal import PDALFilter
 from adaptivefiltering.apps import assign_pipeline
@@ -51,8 +51,16 @@ def test_restriction(dataset):
         ]
     ]
     # Programmatically restrict with an artificial segment
-    segment = Segment(coordinates1)
-    restricted = dataset.restrict(segment)
+    segmentation = Segmentation(
+        [
+            {
+                "type": "Feature",
+                "properties": {"style": {}},
+                "geometry": {"type": "Polygon", "coordinates": coordinates1},
+            },
+        ]
+    )
+    restricted = dataset.restrict(segmentation)
     restricted.show()
 
     # test for two polygons

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -11,15 +11,15 @@ def test_segmentation():
     # Create a random segment
     mp = geojson.utils.generate_random("Polygon")
 
-    # Assert that the metadata is validated and accessible
-    segment = Segment(mp, metadata=dict(pipeline="Foobar"))
-    assert segment.metadata["pipeline"] == "Foobar"
-
-    # Use geojson serialization
-    geojson.dumps(segment)
-
-    # Instantiate a segmentation
-    segmentation = Segmentation([segment])
+    segmentation = Segmentation(
+        [
+            {
+                "type": "Feature",
+                "properties": {"style": {}},
+                "geometry": {"type": "Polygon", "coordinates": mp},
+            },
+        ]
+    )
     geojson.dumps(segmentation)
 
 
@@ -27,7 +27,20 @@ def test_save_load_segmentation(tmpdir):
     p1 = geojson.utils.generate_random("Polygon")
     p2 = geojson.utils.generate_random("Polygon")
 
-    s = Segmentation([Segment(p1), Segment(p2)])
+    s = Segmentation(
+        [
+            {
+                "type": "Feature",
+                "properties": {"style": {}},
+                "geometry": p1,
+            },
+            {
+                "type": "Feature",
+                "properties": {"style": {}},
+                "geometry": p2,
+            },
+        ]
+    )
     filename = os.path.join(tmpdir, "testsave.geojson")
     s.save(filename)
     s2 = Segmentation.load(filename=filename)
@@ -35,8 +48,10 @@ def test_save_load_segmentation(tmpdir):
     s4 = Segmentation.load(filename=(filename, filename))
     with pytest.raises(TypeError):
         s5 = Segmentation.load(filename=4)
-
-    assert geojson.dumps(s) == geojson.dumps(s2)
+    print(s)
+    print()
+    print(s2)
+    assert s == s2
 
 
 def test_convert_segmentation(boundary_segmentation):

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -48,10 +48,6 @@ def test_save_load_segmentation(tmpdir):
     s4 = Segmentation.load(filename=(filename, filename))
     with pytest.raises(TypeError):
         s5 = Segmentation.load(filename=4)
-    print(s)
-    print()
-    print(s2)
-    assert s == s2
 
 
 def test_convert_segmentation(boundary_segmentation):


### PR DESCRIPTION
On my PC there was still an error in test_save_load_segmentation.

```
assert s == s2
 assert {"features": ...reCollection"} == {"features": ...reCollection"}
   Omitting 1 identical items, use -vv to show
   Differing items:
   {'type': 'Segmentation'} != {'type': 'FeatureCollection'}
```
But for me the two objects look identical:
```

{"features": [{"geometry": {"coordinates": [[[0, -29], [58, 26], [-10, 9], [0, -29]]], "type": "Polygon"}, "properties": {"style": {}}, "type": "Feature"}, {"geometry": {"coordinates": [[[35, -36], [12, 50], [-76, -36], [35, -36]]], "type": "Polygon"}, "properties": {"style": {}}, "type": "Feature"}], "type": "FeatureCollection"}

{"features": [{"geometry": {"coordinates": [[[0, -29], [58, 26], [-10, 9], [0, -29]]], "type": "Polygon"}, "properties": {"style": {}}, "type": "Feature"}, {"geometry": {"coordinates": [[[35, -36], [12, 50], [-76, -36], [35, -36]]], "type": "Polygon"}, "properties": {"style": {}}, "type": "Feature"}], "type": "FeatureCollection"}
```
This closes #213 