### PR TITLE
[bugfix] Ensure that variability is passed when copying filters

### DIFF
--- a/adaptivefiltering/filter.py
+++ b/adaptivefiltering/filter.py
@@ -257,6 +257,7 @@ class Filter:
             created instance of this filter.
         :type kwargs: dict
         """
+        kwargs.setdefault("_variability", self._variability)
         return type(self)(**self.config.update(kwargs))
 
     def as_pipeline(self):


### PR DESCRIPTION
This fixes #247 