### PR TITLE
Make filters with no keywords visible in library selection

### DIFF
--- a/adaptivefiltering/apps.py
+++ b/adaptivefiltering/apps.py
@@ -1092,8 +1092,8 @@ def select_pipeline_from_library(multiple=False):
                     continue
 
                 # If the filter does not have at least one selected keyword -> skip
-                # Exception: No keywords are specified at all in the library (early dev)
-                if library_keywords():
+                # Exception: The filter defines no keywords (otherwise it is not discoverable)
+                if filter_.keywords:
                     if not set(keyword_widget.value).intersection(
                         set(filter_.keywords)
                     ):


### PR DESCRIPTION
So far, this depended on the existence of a filter with keywords.

This fixes #303 